### PR TITLE
Fix gradle plugin

### DIFF
--- a/compiler/src/main/java/com/bugvm/compiler/config/Config.java
+++ b/compiler/src/main/java/com/bugvm/compiler/config/Config.java
@@ -184,7 +184,7 @@ public class Config {
 
     private Home home = null;
     private File tmpDir;
-    private File cacheDir = new File(System.getProperty("user.home"), ".bugvm/cache");
+    private File cacheDir = getDefaultCacheDir();
     private File ccBinPath = null;
 
     private boolean clean = false;
@@ -227,6 +227,10 @@ public class Config {
                 new LambdaPlugin()
                 ));
         this.loadPluginsFromClassPath();
+    }
+
+    public static File getDefaultCacheDir () {
+        return new File(System.getProperty("user.home"), ".bugvm/cache");
     }
 
     /**

--- a/gradle/src/main/java/com/bugvm/gradle/BugVMPluginExtension.java
+++ b/gradle/src/main/java/com/bugvm/gradle/BugVMPluginExtension.java
@@ -191,7 +191,7 @@ public class BugVMPluginExtension {
         this.installDir = installDir;
     }
     
-    public void setCachedir(String cacheDir) {
+    public void setCacheDir(String cacheDir) {
         this.cacheDir = cacheDir;
     }
     

--- a/gradle/src/main/java/com/bugvm/gradle/tasks/AbstractBugVMTask.java
+++ b/gradle/src/main/java/com/bugvm/gradle/tasks/AbstractBugVMTask.java
@@ -167,7 +167,7 @@ abstract public class AbstractBugVMTask extends DefaultTask {
         if(extension.getCacheDir() != null) {
             cacheDir = new File(extension.getCacheDir());
         } else {
-            cacheDir = new File(extension.getCacheDir());//Config.getDefaultCacheDir();
+            cacheDir = Config.getDefaultCacheDir();
         }
         File temporaryDirectory = new File(project.getBuildDir(), "bugvm.tmp");
         try {
@@ -238,7 +238,7 @@ abstract public class AbstractBugVMTask extends DefaultTask {
     abstract public void invoke();
 
     protected File unpack() throws GradleException {
-        final Artifact artifact = resolveArtifact("com.bugvm:bugvm-dist:tar.gz:nocompiler:"
+        final Artifact artifact = resolveArtifact("com.bugvm:bugvm-dist:tar.gz:"
                 + BugVMPlugin.getBugVMVersion());
         final File distTarFile = artifact.getFile();
         final File unpackedDirectory = new File(distTarFile.getParent(), "unpacked");


### PR DESCRIPTION
Fixed setter name for `cacheDir`.
Added `getDefaultCacheDir()` method to `Config`, to avoid NPE.
Fixed the artifact name being unpacked in `AbstractBugVMTask` since the `nocompiler` artifact is not published.
